### PR TITLE
Update load_to_mongo code to explicitly drop/rename fields.

### DIFF
--- a/convert_db.py
+++ b/convert_db.py
@@ -21,6 +21,7 @@ def transform_shred(shred_dict):
 
     shred_fields_map = {
         'tags_suggestions': 'tags',
+        'features_fname': 'mask_fname',
         'name': 'name',
         'sheet': 'sheet',
         'piece_fname': 'piece_fname',
@@ -55,7 +56,8 @@ def transform_shred(shred_dict):
         shred_fields['features'][dst] = shred_fields['features'].pop(src)
 
     for name in drop_fields:
-        del shred[name]
+        if name in shred:
+            del shred[name]
     for feature in drop_features:
         del shred_fields['features'][feature]
 

--- a/fixtures/shreds.json
+++ b/fixtures/shreds.json
@@ -2,6 +2,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -827,6 +829,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -1670,6 +1674,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -2619,6 +2625,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -3338,6 +3346,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -3883,6 +3893,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -4370,6 +4382,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -5145,6 +5159,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -5848,6 +5864,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 
@@ -6763,6 +6781,8 @@
  {
   "sheet": "6", 
   "features": {
+   "width": 10,
+   "height": 20,
    "histogram_clean": [
     0, 
     0, 

--- a/models/shreds.py
+++ b/models/shreds.py
@@ -13,16 +13,16 @@ from .user import User
 
 class Features(EmbeddedDocument):
     histogram_clean = ListField(IntField())
-    height_mm = FloatField(default=0.0)
+    height_mm = FloatField(required=True)
     histogram_full = ListField(IntField())
-    width_mm = FloatField(default=0.0)
-    area = IntField(default=0)
+    width_mm = FloatField(required=True)
+    area = IntField(required=True)
     dominant_colours = ListField(StringField())
-    solidity = FloatField(default=0.0)
+    solidity = FloatField(required=True)
     colour_names = ListField(StringField())
-    ratio = FloatField(default=0.0)
-    width = IntField(default=0)
-    height = IntField(default=0)
+    ratio = FloatField(required=True)
+    width = IntField(required=True)
+    height = IntField(required=True)
 
 
 class ShredTags(EmbeddedDocument):
@@ -36,14 +36,14 @@ class ShredTags(EmbeddedDocument):
 # Immutable once imported from CV.
 class Shred(Document):
     id = StringField(max_length=200, default='', primary_key=True)
-    name = IntField()
+    name = IntField(required=True)
     features = EmbeddedDocumentField(Features)
     tags = ListField(StringField())
     contour = ListField(ListField(IntField()))
-    sheet = StringField()
-    piece_fname = StringField()
-    piece_in_context_fname = StringField()
-    mask_fname = StringField()
+    sheet = StringField(required=True)
+    piece_fname = StringField(required=True)
+    piece_in_context_fname = StringField(required=True)
+    mask_fname = StringField(required=True)
 
     def get_auto_tags(self):
         mapping = Tags.objects.get_tag_synonyms()
@@ -61,9 +61,9 @@ class ClusterMember(EmbeddedDocument):
     Relative shred position is stored as rotation angle (in radians) and
     (x, y) translation relative to cluster origin.
     """
-    shred = ReferenceField(Shred)
+    shred = ReferenceField(Shred, required=True)
     position = ListField(FloatField())
-    angle = FloatField()
+    angle = FloatField(required=True)
 
     def __unicode__(self):
         return self.shred.id
@@ -85,7 +85,7 @@ class Cluster(Document):
     users_processed = ListField(ReferenceField(User),
                                 db_field='usersProcessed')
 
-    batch = StringField()
+    batch = StringField(required=True)
     tags = ListField(EmbeddedDocumentField(ShredTags))
 
     members = ListField(EmbeddedDocumentField(ClusterMember))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,7 +16,7 @@ class FixturesTest(BasicTestCase):
         self.assertEquals(res.json, {"result": True})
 
     def test_reset_db(self):
-        Cluster().save()
+        Cluster(batch="a").save()
         Tags().save()
         TaggingSpeed().save()
         User().save()


### PR DESCRIPTION
After recent mongoengine updated it became more pedantic about unexpected fields.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dchaplinsky/unshred-tag/81)

<!-- Reviewable:end -->
